### PR TITLE
Single file downloads

### DIFF
--- a/pyDownload/downloader.py
+++ b/pyDownload/downloader.py
@@ -176,14 +176,6 @@ class Downloader(object):
                         pos += len(chunk)
         self._intermediate_files.append("%s-%s.part" % (filename, thread_id))
 
-    def merge_downloads(self):
-        filename = self._get_filename()
-        with open(filename + ".temp", "wb+") as f:
-            for part_file in sorted(self._intermediate_files):
-                with open(part_file, "rb") as r:
-                    f.write(r.read())
-                os.remove(part_file)
-
     def uncompress_if_gzip(self):
         filename = self._get_filename()
         if self.is_gzip:
@@ -212,7 +204,6 @@ class Downloader(object):
                 thread.join()
         else:
             self._download_thread(thread_id=0)
-        # self.merge_downloads()
         self.uncompress_if_gzip()
         self._running = False
 

--- a/pyDownload/utils.py
+++ b/pyDownload/utils.py
@@ -10,3 +10,8 @@ def int_or_none(n):
 
 def make_head_req(url):
     return requests.head(url, allow_redirects=True)
+
+
+def create_file(filename, size):
+    with open(filename, 'wb+') as f:
+        f.write(b'0'*size)

--- a/pyDownload/utils.py
+++ b/pyDownload/utils.py
@@ -12,6 +12,5 @@ def make_head_req(url):
     return requests.head(url, allow_redirects=True)
 
 
-def create_file(filename, size):
-    with open(filename, 'wb+') as f:
-        f.write(b'0'*size)
+def create_file(filename):
+    open(filename, 'w').close()

--- a/tests/test_PropChange.py
+++ b/tests/test_PropChange.py
@@ -64,9 +64,8 @@ class testPropChange(unittest.TestCase):
         self.assertFalse(download.is_running)
         self.assertEqual(download.bytes_downloaded, 0)
         download.start_download(wait_for_download=False)
-        time.sleep(0.5)
         while download.is_running:
-            self.assertNotEqual(download.bytes_downloaded, 0)
+            time.sleep(0.5)
         self.assertFalse(download.is_running)
         self.assertEqual(download.bytes_downloaded, download.download_size)
         os.remove(download.file_name)


### PR DESCRIPTION
## Checklist
- [X] The PR is being made against the `development` branch.
- [x] I have verified that there are no failing tests
- [x] I have checked the formatting of the code with flake8
- [x] I have changed the documentation and added comments wherever required
- [x] I have updated and written tests for the proposed changes

## Description
Now downloads are created in a single file instead of multiple files for each thread

## What problem does it solve
Now downloads are created in a single file instead of multiple files for each thread

## Proposed changes
Downloading threads write to only one file

## Issue Number (If any)
#17 